### PR TITLE
change param names as specified in indradb.proto(indradb/indradb)

### DIFF
--- a/indradb/models.py
+++ b/indradb/models.py
@@ -152,7 +152,7 @@ class PropertyPresenceVertexQuery(_VertexQuery):
 
     def to_message(self):
         return proto.VertexQuery(
-            range=proto.PropertyPresenceVertexQuery(
+            property_presence=proto.PropertyPresenceVertexQuery(
                 name=proto.Identifier(value=self._name),
             ),
         )
@@ -166,7 +166,7 @@ class PropertyValueVertexQuery(_VertexQuery):
 
     def to_message(self):
         return proto.VertexQuery(
-            range=proto.PropertyValueVertexQuery(
+            property_value=proto.PropertyValueVertexQuery(
                 name=proto.Identifier(value=self._name),
                 value=json.dumps(self._value),
             ),
@@ -182,7 +182,7 @@ class PipePropertyPresenceVertexQuery(_VertexQuery):
 
     def to_message(self):
         return proto.VertexQuery(
-            range=proto.PipePropertyPresenceVertexQuery(
+            pipe_property_presence=proto.PipePropertyPresenceVertexQuery(
                 inner=self._inner.to_message(),
                 name=proto.Identifier(value=self._name),
                 exists=self._exists,
@@ -200,7 +200,7 @@ class PipePropertyValueVertexQuery(_VertexQuery):
 
     def to_message(self):
         return proto.VertexQuery(
-            range=proto.PropertyValueVertexQuery(
+            pipe_property_value=proto.PropertyValueVertexQuery(
                 inner=self._inner.to_message(),
                 name=proto.Identifier(value=self._name),
                 value=json.dumps(self._value),


### PR DESCRIPTION
```
// A query for vertices.
message VertexQuery {
    oneof query {
        RangeVertexQuery range = 1;
        SpecificVertexQuery specific = 2;
        PipeVertexQuery pipe = 3;
        PropertyPresenceVertexQuery property_presence = 4;
        PropertyValueVertexQuery property_value = 5;
        PipePropertyPresenceVertexQuery pipe_property_presence = 6;
        PipePropertyValueVertexQuery pipe_property_value = 7;
    }
}
```

for some VertexQueries
follows param names specified in indradb.proto (https://github.com/indradb/indradb)
